### PR TITLE
Makes cukeforker compatible with latest version of cucumber

### DIFF
--- a/cukeforker.gemspec
+++ b/cukeforker.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "cukeforker"
 
-  s.add_dependency "cucumber"
+  s.add_dependency "cucumber", ">= 1.1.5"
   s.add_dependency "vnctools", "~> 0.0.4"
   s.add_development_dependency "rspec", "~> 2.5"
   s.add_development_dependency "simplecov"

--- a/lib/cukeforker/formatters/scenario_line_logger.rb
+++ b/lib/cukeforker/formatters/scenario_line_logger.rb
@@ -10,7 +10,7 @@ module CukeForker
       end
 
       def visit_feature_element(feature_element)
-        if @tag_expression.eval feature_element.source_tag_names
+        if @tag_expression.eval feature_element.source_tags
           if feature_element.respond_to? :line
             @scenarios <<  "#{feature_element.feature.file}:#{feature_element.line}"
           else

--- a/spec/cukeforker/formatters/scenario_line_logger_spec.rb
+++ b/spec/cukeforker/formatters/scenario_line_logger_spec.rb
@@ -9,7 +9,7 @@ module CukeForker::Formatters
       feature_element = mock("Cucumber::Ast::Scenario")
 
       feature.should_receive(:file).twice.and_return('features/test1.feature')
-      feature_element.should_receive(:source_tag_names).twice.and_return('')
+      feature_element.should_receive(:source_tags).twice.and_return('')
       feature_element.should_receive(:feature).twice.and_return(feature)
       feature_element.should_receive(:line).and_return(3)
       feature_element.should_receive(:line).and_return(6)
@@ -35,7 +35,7 @@ module CukeForker::Formatters
       feature_element = FakeScenarioOutline.new
 
       feature.should_receive(:file).and_return('features/test1.feature')
-      feature_element.should_receive(:source_tag_names).and_return('')
+      feature_element.should_receive(:source_tags).and_return('')
       feature_element.should_receive(:feature).and_return(feature)
 
       logger.visit_feature_element(feature_element)


### PR DESCRIPTION
Changes in the 1.1.5 version of Cucumber broke cukeforker's scenario line logger.  They now compare tag objects rather than tag names.
