### PR TITLE
use RbConfig to find OS so cukeforker can be used with JRuby

### DIFF
--- a/lib/cukeforker.rb
+++ b/lib/cukeforker.rb
@@ -1,4 +1,5 @@
-unless RUBY_PLATFORM =~ /darwin|linux/
+require 'rbconfig'
+unless RbConfig::CONFIG['host_os'] =~ /darwin|linux/
   raise "CukeForker only supported on *nix/MRI"
 end
 


### PR DESCRIPTION
RUBY_PLATFORM  returns 'java' when JRuby is used even if the underlying OS is darwin or linux.  Using rbconfig fixes the issue.
