### PR TITLE
Change kill signal from TERM to INT so aborted tests do not show up as f...

### DIFF
--- a/lib/cukeforker/worker.rb
+++ b/lib/cukeforker/worker.rb
@@ -76,7 +76,7 @@ module CukeForker
     def kill
       if pid
         begin
-          Process.kill("TERM", pid)
+          Process.kill("INT", pid)
           Process.wait(pid)
         rescue
           # Could not kill worker #{w.feature}


### PR DESCRIPTION
...ailures in reports

This was my original reason for using INT instead of TERM. I had forgotten about that.
