### PR TITLE
Cause exit status 1 when there are test failures

### DIFF
--- a/bin/cukeforker
+++ b/bin/cukeforker
@@ -6,4 +6,8 @@ split      = ARGV.index("--")
 extra_args = ARGV[0..(split-1)]
 features   = ARGV[(split+1)..-1]
 
-CukeForker::Runner.run(features, :extra_args => extra_args)
+if CukeForker::Runner.run(features, :extra_args => extra_args)
+  exit 0
+else
+  exit 1
+end

--- a/lib/cukeforker/rake_task.rb
+++ b/lib/cukeforker/rake_task.rb
@@ -1,0 +1,43 @@
+require 'rake'
+require 'rake/tasklib'
+
+module CukeForker
+  class RakeTask < Rake::TaskLib
+    attr_accessor :name
+    attr_accessor :verbose
+    attr_accessor :features
+    attr_accessor :extra_args
+
+    def initialize(*args, &task_block)
+      setup_ivars(args)
+
+      desc 'Run CukeForker' unless ::Rake.application.last_comment
+
+      task(name, *args) do |_, task_args|
+        RakeFileUtils.send(:verbose, verbose) do
+          if task_block
+            task_block.call(*[self, task_args].slice(0, task_block.arity))
+          end
+
+          run_cukeforker
+        end
+      end
+    end
+
+    def setup_ivars(args)
+      @name = args.shift || :cukeforker
+
+      split = args.index("--")
+      if split
+        @extra_args = args[0..(split-1)]
+        @features = args[(split+1)..-1]
+      end
+    end
+
+    def run_cukeforker
+      unless CukeForker::Runner.run(@features, :extra_args => @extra_args)
+        raise 'Test failures'
+      end
+    end
+  end
+end

--- a/lib/cukeforker/runner.rb
+++ b/lib/cukeforker/runner.rb
@@ -99,9 +99,11 @@ module CukeForker
       start
       process
       stop
+      !@queue.has_failures?
     rescue Interrupt
       fire :on_run_interrupted
       stop
+      false
     rescue StandardError
       fire :on_run_interrupted
       stop

--- a/spec/cukeforker/rake_task_spec.rb
+++ b/spec/cukeforker/rake_task_spec.rb
@@ -1,0 +1,47 @@
+require File.expand_path("../../spec_helper", __FILE__)
+
+require 'cukeforker/rake_task'
+
+describe CukeForker::RakeTask do
+  describe 'define task' do
+    it 'creates a cukeforker task' do
+      CukeForker::RakeTask.new
+
+      expect(Rake::Task.task_defined?(:cukeforker)).to be true
+    end
+
+    it 'creates a named task' do
+      CukeForker::RakeTask.new(:run_feature)
+
+      expect(Rake::Task.task_defined?(:run_feature)).to be true
+    end
+  end
+
+  describe 'running task' do
+    before(:each) do
+      Rake::Task['cukeforker'].clear if Rake::Task.task_defined?('cukeforker')
+    end
+
+    it 'runs specific features' do
+      CukeForker::RakeTask.new do |task|
+        task.features = ['file1, file2']
+        task.verbose = false
+      end
+
+      expect(CukeForker::Runner).to receive(:run).and_return(true)
+
+      Rake::Task['cukeforker'].execute
+    end
+
+    it 'exits with a non zero status if any tests fail' do
+      CukeForker::RakeTask.new do |task|
+        task.features = ['file1, file2']
+        task.verbose = false
+      end
+
+      expect(CukeForker::Runner).to receive(:run).and_return(false)
+
+      expect { Rake::Task['cukeforker'].execute }.to raise_error(Exception)
+    end
+  end
+end

--- a/spec/cukeforker/runner_spec.rb
+++ b/spec/cukeforker/runner_spec.rb
@@ -126,5 +126,25 @@ module CukeForker
       end
     end
 
+    context 'exit status' do
+      let(:queue)    { double(Queue) }
+      let(:runner)   { Runner.new(queue) }
+
+      it 'returns true when there are no test failures' do
+        queue.stub(:has_failures? => false)
+        queue.should_receive(:process).with 0.2 # poll interval
+        queue.should_receive(:wait_until_finished)
+
+        expect(runner.run).to be_true
+      end
+
+      it 'returns false when there are test failures' do
+        queue.stub(:has_failures? => true)
+        queue.should_receive(:process).with 0.2 # poll interval
+        queue.should_receive(:wait_until_finished)
+
+        expect(runner.run).to be_false
+      end
+    end
   end # Runner
 end # CukeForker


### PR DESCRIPTION
We have CukeForker wired up to a Jenkins build. Whenever there is a failure in the CukeForker runner, our build shows as green instead of red because CukeForker will exit with a status code of 0. This change will cause the exit status to be 1 if there are any test failures.