### PR TITLE
Change to raise Error instead of exit true or false

### DIFF
--- a/bin/cukeforker
+++ b/bin/cukeforker
@@ -6,8 +6,4 @@ split      = ARGV.index("--")
 extra_args = ARGV[0..(split-1)]
 features   = ARGV[(split+1)..-1]
 
-if CukeForker::Runner.run(features, :extra_args => extra_args)
-  exit 0
-else
-  exit 1
-end
+CukeForker::Runner.run(features, :extra_args => extra_args)

--- a/lib/cukeforker/rake_task.rb
+++ b/lib/cukeforker/rake_task.rb
@@ -35,9 +35,7 @@ module CukeForker
     end
 
     def run_cukeforker
-      unless CukeForker::Runner.run(@features, :extra_args => @extra_args)
-        raise 'Test failures'
-      end
+      CukeForker::Runner.run(@features, :extra_args => @extra_args)
     end
   end
 end

--- a/lib/cukeforker/runner.rb
+++ b/lib/cukeforker/runner.rb
@@ -21,6 +21,8 @@ module CukeForker
   #   :delay      => Numeric           seconds to sleep between each worker is started (default: 0)
   #
 
+  class TestFailureError < StandardError; end
+
   class Runner
     include Observable
 
@@ -99,11 +101,10 @@ module CukeForker
       start
       process
       stop
-      !@queue.has_failures?
+      raise TestFailureError if @queue.has_failures?
     rescue Interrupt
       fire :on_run_interrupted
       stop
-      false
     rescue StandardError
       fire :on_run_interrupted
       stop

--- a/spec/cukeforker/rake_task_spec.rb
+++ b/spec/cukeforker/rake_task_spec.rb
@@ -39,9 +39,9 @@ describe CukeForker::RakeTask do
         task.verbose = false
       end
 
-      expect(CukeForker::Runner).to receive(:run).and_return(false)
+      expect(CukeForker::Runner).to receive(:run).and_raise(CukeForker::TestFailureError)
 
-      expect { Rake::Task['cukeforker'].execute }.to raise_error(Exception)
+      expect { Rake::Task['cukeforker'].execute }.to raise_error(CukeForker::TestFailureError)
     end
   end
 end

--- a/spec/cukeforker/runner_spec.rb
+++ b/spec/cukeforker/runner_spec.rb
@@ -127,23 +127,23 @@ module CukeForker
     end
 
     context 'exit status' do
-      let(:queue)    { double(Queue) }
-      let(:runner)   { Runner.new(queue) }
+      let(:queue) { double(Queue) }
+      let(:runner) { Runner.new(queue) }
 
       it 'returns true when there are no test failures' do
         queue.stub(:has_failures? => false)
-        queue.should_receive(:process).with 0.2 # poll interval
-        queue.should_receive(:wait_until_finished)
+        expect(queue).to receive(:process).with(0.2)
+        expect(queue).to receive(:wait_until_finished)
 
-        expect(runner.run).to be_true
+        expect { runner.run }.to_not raise_error(TestFailureError)
       end
 
       it 'returns false when there are test failures' do
         queue.stub(:has_failures? => true)
-        queue.should_receive(:process).with 0.2 # poll interval
-        queue.should_receive(:wait_until_finished)
+        expect(queue).to receive(:process).with(0.2)
+        expect(queue).to receive(:wait_until_finished).twice
 
-        expect(runner.run).to be_false
+        expect { runner.run }.to raise_error(TestFailureError)
       end
     end
   end # Runner


### PR DESCRIPTION
I have been thinking it over, and I do not know how much I liked having CukeForker return true or false. By having it raise an Error, it will cause a non 0 exit and still be easy to account for in reliant code. To your point from before, this could open the possibility to give different exit statuses based on the failure.